### PR TITLE
Hide toolbar on client connection

### DIFF
--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -4091,6 +4091,12 @@ async fn start_ipc(
         #[cfg(target_os = "linux")]
         let mut user = None;
 
+        // 在Windows平台上使用无UI模式，避免弹出窗口
+        #[cfg(target_os = "windows")]
+        {
+            args = vec!["--cm-no-ui"];
+        }
+
         // Cm run as user, wait until desktop session is ready.
         #[cfg(target_os = "linux")]
         if crate::platform::is_headless_allowed() && linux_desktop_manager::is_headless() {

--- a/src/ui/common.tis
+++ b/src/ui/common.tis
@@ -122,6 +122,13 @@ function adjustBorder() {
         }
         return;
     }
+    // 在Windows平台上，始终隐藏工具栏（除了文件传输和端口转发）
+    if (is_win && !is_file_transfer && !is_port_forward) {
+        $(header).style.set {
+            display: "none",
+        };
+        // 继续执行边框调整逻辑，但不显示工具栏
+    }
     if (view.windowState == view.WINDOW_MAXIMIZED) {
         self.style.set {
             border: "window-frame-width solid transparent",

--- a/src/ui/header.tis
+++ b/src/ui/header.tis
@@ -57,6 +57,12 @@ function stateChanged() {
             display: "none",
         };
     }
+    // 在Windows平台上，无论是否全屏都隐藏工具栏
+    if (is_win && !is_file_transfer && !is_port_forward) {
+        $(header).style.set {
+            display: "none",
+        };
+    }
 }
 
 var header;
@@ -517,6 +523,12 @@ if (!(is_file_transfer || is_port_forward)) {
     if (!is_osx) {
         $(div.window-icon).style.set {
             size: "32px",
+        };
+    }
+    // 在Windows平台上初始化时就隐藏工具栏
+    if (is_win) {
+        $(header).style.set {
+            display: "none",
         };
     }
 }

--- a/src/ui/remote.tis
+++ b/src/ui/remote.tis
@@ -147,7 +147,8 @@ function handler.onMouse(evt)
 {
     is_mouse_event_triggered = true;
     if (is_file_transfer || is_port_forward) return false;
-    if (view.windowState == View.WINDOW_FULL_SCREEN && !dragging) {
+    // 在Windows平台上禁用工具栏自动弹出功能
+    if (view.windowState == View.WINDOW_FULL_SCREEN && !dragging && !is_win) {
         var dy = evt.y - scroll_body.scroll(#top);
         if (dy <= 1) {
             if (!wait_window_toolbar) {


### PR DESCRIPTION
Disable toolbar auto-popup on Windows controlled client to provide a cleaner UI experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-6cd34922-a9bc-4baf-ab73-7f5553580c21">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6cd34922-a9bc-4baf-ab73-7f5553580c21">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

